### PR TITLE
Added a basic htogg reader

### DIFF
--- a/core/io/treecursion_types.cpp
+++ b/core/io/treecursion_types.cpp
@@ -63,7 +63,6 @@ Ref<TreecursionWriteTask> TreecursionTestData::variant2write_task(const Variant 
 		}
 	}
 	return Ref<TreecursionWriteTask>(nullptr);
-
 }
 Ref<TreecursionWriteTask> TreecursionTestData::peek(){
 	Ref<TreecursionWriteTask> ret = commands[counter];

--- a/core/io/treecursion_types.h
+++ b/core/io/treecursion_types.h
@@ -190,6 +190,9 @@ public:
 		Error err = w.write_to_string(init_vars, ret);
 		return ret;
 	}
+	Dictionary get_vars() const {
+		return init_vars.duplicate();
+	}
 };
 
 

--- a/modules/talkingtree_storage/ogg_routines.cpp
+++ b/modules/talkingtree_storage/ogg_routines.cpp
@@ -2,8 +2,9 @@
 #include "ogg_routines.h"
 
 #include "ustring.h"
+#include "os/copymem.h"
 #include <string.h>
-
+#include <stdlib.h>
 //https://dismaldenizen.wordpress.com/2010/08/20/the-ogg-container-format-explained/
 int htogg_write_page(ogg_page *page, FileAccess *fa){
 	fa->store_buffer(page->header, page->header_len);
@@ -11,11 +12,29 @@ int htogg_write_page(ogg_page *page, FileAccess *fa){
 	return page->header_len + page->body_len;
 }
 
+void ogg_page_init(ogg_page *page){
+	page ->header = NULL;
+	page ->header_len = 0;
+	page ->body = NULL;
+	page -> body_len = 0;
+}
+
+void ogg_page_clear(ogg_page * page){
+	if(page->header && page->body){
+		_ogg_free(page->header);
+	}
+	ogg_page_init(page);
+}
+
+void ogg_packet_init(ogg_packet * packet){
+	zeromem(packet, sizeof(ogg_packet));
+}
+
 int ogg_buffer(FileAccess *fa, ogg_sync_state *oy){
   uint8_t * buffer  = (uint8_t *) ogg_sync_buffer (oy, 4096);
   int bytes = fa->get_buffer(buffer, 4096);
   ogg_sync_wrote (oy,bytes);
-  return (bytes);
+  return bytes;
 }
 
 bool is_fishhead_packet(ogg_packet *packet){

--- a/modules/talkingtree_storage/ogg_routines.h
+++ b/modules/talkingtree_storage/ogg_routines.h
@@ -1,10 +1,17 @@
 #include "ogg/ogg.h"
 #include "os/file_access.h"
 
-
+#ifndef HTOGG_ROUTES_H
+#define HTOGG_ROUTES_H
 int htogg_write_page(ogg_page *page, FileAccess *fa);
 
 int ogg_buffer(FileAccess *fa, ogg_sync_state *oy);
+
+void ogg_page_init(ogg_page *page);
+
+void ogg_page_clear(ogg_page * page);
+
+void ogg_packet_init(ogg_packet *packet);
 
 bool is_fishhead_packet(ogg_packet *packet);
 
@@ -15,4 +22,6 @@ unsigned char * write_le32(unsigned char* p, const ogg_uint32_t num);
 unsigned char * write_le16(unsigned char* p, const ogg_uint32_t num);
 
 unsigned char * write_le64(unsigned char* p, const ogg_int64_t num);
+
+#endif HTOGG_ROUTES_H
 

--- a/modules/talkingtree_storage/register_types.cpp
+++ b/modules/talkingtree_storage/register_types.cpp
@@ -1,32 +1,53 @@
 #include "register_types.h"
 #include "class_db.h"
 #include "talking_tree_storage.h"
+#include "treecursion_reader.h"
 #include "talkingtree_storage_loader.h"
+#include "treecursion_player.h"
 #include "engine.h"
 
 
 static ResourceFormatTalkingTreeStorage *talkingtree_storage_loader = NULL;
+
 static TalkingTreeStorage *talking_tree_storage_writer = NULL;
+static _TalkingTreeStorage *_talking_tree_storage = NULL;
 
-
-static _TalkingTreeStorage *talking_tree_storage = NULL;
+static TreecursionPlayer *treecursion_player = NULL;
+static _TreecursionPlayer *_treecursion_player = NULL;
 
 void register_talkingtree_storage_types(){
-
-
+	//loader
 	talkingtree_storage_loader = memnew(ResourceFormatTalkingTreeStorage);
     ResourceLoader::add_resource_format_loader(talkingtree_storage_loader);
 
+	//writer
 	talking_tree_storage_writer = memnew(TalkingTreeStorage);
 	talking_tree_storage_writer->init();
-	talking_tree_storage_writer->set_singleton();
-	//ClassDB::register_class<TreecursionWriter>();
 
-
-	talking_tree_storage = memnew(_TalkingTreeStorage);
+	_talking_tree_storage = memnew(_TalkingTreeStorage);
 	ClassDB::register_class<_TalkingTreeStorage>();
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TalkingTreeStorage", _TalkingTreeStorage::get_singleton()));
+
+	//reader
+	ClassDB::register_class<Treecursion>();
+
+	//submission queue
+	treecursion_player = memnew(TreecursionPlayer);
+	treecursion_player->init();
+	_treecursion_player = memnew(_TreecursionPlayer);
+	ClassDB::register_class<_TreecursionPlayer>();
+	Engine::get_singleton()->add_singleton(Engine::Singleton("TreecursionPlayer", _TreecursionPlayer::get_singleton()));
+
 }
 void unregister_talkingtree_storage_types(){
 	talking_tree_storage_writer->finish();
+	treecursion_player->finish();
+
+	memdelete(talkingtree_storage_loader);
+
+	memdelete(_treecursion_player);
+	memdelete(_talking_tree_storage);
+
+	memdelete(treecursion_player);
+	memdelete(talking_tree_storage_writer);
 }

--- a/modules/talkingtree_storage/talking_tree_storage.cpp
+++ b/modules/talkingtree_storage/talking_tree_storage.cpp
@@ -48,9 +48,6 @@ TalkingTreeStorage *TalkingTreeStorage::_singleton = NULL;
 TalkingTreeStorage *TalkingTreeStorage::get_singleton() {
 	return _singleton;
 }
-void TalkingTreeStorage::set_singleton() {
-	_singleton = this;
-}
 
 void TalkingTreeStorage::new_file(){
 //	_treecursion = memnew(TreecursionWriter());
@@ -159,7 +156,7 @@ void TalkingTreeStorage::finish() {
 
 TalkingTreeStorage::TalkingTreeStorage() : _recording_state(ERROR) {
 	//opusEncoder = opus_multistream_encoder_create();
-	
+	_singleton = this;
 }
 
 TalkingTreeStorage::~TalkingTreeStorage() {
@@ -187,9 +184,7 @@ void _TalkingTreeStorage::set_file_name(String name){
 	//TalkingTreeStorage::get_singleton()->set_file_name(name);
 }
 _TalkingTreeStorage::_TalkingTreeStorage() {
-	_singleton = this;
-	TalkingTreeStorage::get_singleton()->init();
-	
+	_singleton = this;	
 }
 _TalkingTreeStorage::~_TalkingTreeStorage() {
 	_singleton = nullptr;

--- a/modules/talkingtree_storage/talking_tree_storage.h
+++ b/modules/talkingtree_storage/talking_tree_storage.h
@@ -2,8 +2,6 @@
 #ifndef TALKING_TREE_STORAGE_H
 #define TALKING_TREE_STORAGE_H
 
-
-
 #include "object.h"
 #include "variant.h"
 #include "core/os/thread.h"
@@ -28,7 +26,6 @@ class TalkingTreeStorage : public Object {
 	static void thread_func(void *p_udata);
 public:
 	static TalkingTreeStorage *get_singleton();
-	void set_singleton();
 	void lock();
 	void unlock();
 	void finish();

--- a/modules/talkingtree_storage/talkingtree_storage_loader.cpp
+++ b/modules/talkingtree_storage/talkingtree_storage_loader.cpp
@@ -5,12 +5,11 @@
 ResourceFormatTalkingTreeStorage::ResourceFormatTalkingTreeStorage() {
 }
 RES ResourceFormatTalkingTreeStorage::load(const String &p_path, const String &p_original_path, Error *r_error) {
+	Treecursion *treecursion = memnew(Treecursion);
+	treecursion->set_file(p_path);
 	if (r_error)
 		*r_error = OK;
-
-	TreecursionReader *treecursion = memnew(TreecursionReader);
-	treecursion->set_file(p_path);
-	return Ref<TreecursionReader>(treecursion);
+	return Ref<Treecursion>(treecursion);
 }
 
 void ResourceFormatTalkingTreeStorage::get_recognized_extensions(List<String> *p_extensions) const {

--- a/modules/talkingtree_storage/treecursion_player.cpp
+++ b/modules/talkingtree_storage/treecursion_player.cpp
@@ -1,0 +1,171 @@
+#include "treecursion_player.h"
+#include "os/os.h"
+#include "message_queue.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/node.h"
+#include "scene/main/viewport.h"
+#include "error_macros.h"
+
+TreecursionPlayer *TreecursionPlayer::_singleton = nullptr;
+
+TreecursionPlayer::TreecursionPlayer() : state(ERROR) {
+	_singleton = this;
+}
+TreecursionPlayer::~TreecursionPlayer() {
+	
+}
+TreecursionPlayer *TreecursionPlayer::get_singleton(){
+	return _singleton;
+}
+void TreecursionPlayer::_bind_methods() {
+
+}
+
+void TreecursionPlayer::lock() {
+	if (!_thread || !_mutex)
+		return;
+	_mutex->lock();
+}
+void TreecursionPlayer::unlock() {
+	if (!_thread || !_mutex)
+		return;
+	_mutex->unlock();
+}
+
+
+Error TreecursionPlayer::init(){
+	_thread_exited = false;
+	_mutex = Mutex::create();
+	_thread = Thread::create(TreecursionPlayer::thread_func, this);
+	return OK;
+}
+
+
+void TreecursionPlayer::thread_func(void *p_udata){
+	TreecursionPlayer *ac = (TreecursionPlayer *) p_udata;
+
+	uint64_t usdelay = 20000;
+	while(!ac -> _exit_thread){
+		if(!ac->is_paused()) {
+			ac->flush();
+			OS::get_singleton()->delay_usec(usdelay);
+		}
+	}
+}
+void TreecursionPlayer::set_pause(bool paused) {
+	if(state == ERROR)
+		return;
+	if(paused){
+		state = PAUSED;
+	} else {
+		state = RUNNING;
+	}
+}
+bool TreecursionPlayer::is_paused() const {
+	return state != RUNNING;
+}
+void TreecursionPlayer::close_file() {
+	reader.unref();
+	state = ERROR;
+}
+void TreecursionPlayer::finish() {
+	if (!_thread)
+		return;
+	_exit_thread = true;
+	Thread::wait_to_finish(_thread);
+	close_file();
+	memdelete(_thread);
+	if (_mutex)
+		memdelete(_mutex);
+	_thread = NULL;
+}
+
+void TreecursionPlayer::set_treecursion_reader( Ref<Treecursion> &in_reader){
+	if(reader.is_valid()){
+		reader.unref();
+	}
+	
+	if(in_reader.is_valid()){
+		reader = in_reader->instance_playback();
+		state = PAUSED;
+	} else {
+		ERR_PRINTS("Treecursion HTOGG file is invalid");
+	}
+}
+Variant TreecursionPlayer::get_init_vars() const {
+	return reader->get_init_values();
+}
+void TreecursionPlayer::flush(){
+	uint64_t current_time = OS::get_singleton()->get_ticks_usec();
+	while(reader->has_next()) {
+		uint64_t next_cmd_time = reader->peek_time();
+		if(current_time > next_cmd_time) {
+			Ref<TreecursionWriteTask> t = reader->pop();
+			push_task(t);
+			//print_line(t->toString());
+		}else
+			break;
+	}
+}
+void TreecursionPlayer::print_all_task_time(){
+	while(reader->has_next()) {
+		Ref<TreecursionWriteTask> t = reader->pop();
+		print_line("command time: " + itos(t->get_time()) + t->toJson());
+	}
+}
+void TreecursionPlayer::push_task(const Ref<TreecursionWriteTask> &task){
+	Node *node = NULL;
+	switch(task->get_type()){
+		case TreecursionWriteTask::CALL_TASK: {
+			TreecursionCallTask *ct = (TreecursionCallTask *)task.ptr();
+
+			Vector<Variant> args(ct->get_args());
+			int argc = args.size();
+			Vector<Variant *> argp;
+			argp.resize(argc);
+			for (int i = 0; i < argc; i++) {
+				argp[i] = &args[i];
+			}
+			node = SceneTree::get_singleton()->get_root()->get_node(ct -> get_node_path());
+			MessageQueue::get_singleton()->push_call(node->get_instance_id(), ct->get_name(), (const Variant **)argp.ptr(), argc, true);
+			break;
+		}
+		case TreecursionWriteTask::SET_TASK: {
+			TreecursionSetTask *st = (TreecursionSetTask *)task.ptr();
+			bool valid;
+			node = SceneTree::get_singleton()->get_root()->get_node(st -> get_node_path());
+			MessageQueue::get_singleton()->push_set(node, st->get_name(), st ->get_value());
+			break;
+		}
+		default:
+			break;
+	}
+
+}
+
+_TreecursionPlayer *_TreecursionPlayer::_singleton = nullptr;
+
+void _TreecursionPlayer::set_treecursion_reader( Ref<Treecursion> in_reader) {
+	TreecursionPlayer::get_singleton()->set_treecursion_reader(in_reader);
+}
+void _TreecursionPlayer::print_all_task_time(){
+	TreecursionPlayer::get_singleton()->print_all_task_time();
+}
+Variant _TreecursionPlayer::get_init_values() const {
+	return TreecursionPlayer::get_singleton()->get_init_vars();
+}
+void _TreecursionPlayer::set_pause(bool paused) {
+	TreecursionPlayer::get_singleton()->set_pause(paused);
+}
+void _TreecursionPlayer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_pause", "enable"), &_TreecursionPlayer::set_pause);
+	ClassDB::bind_method(D_METHOD("get_init_values"), &_TreecursionPlayer::get_init_values);
+	ClassDB::bind_method(D_METHOD("set_treecursion", "treecursion"), &_TreecursionPlayer::set_treecursion_reader);
+	ClassDB::bind_method(D_METHOD("print_all_task_time"), &_TreecursionPlayer::print_all_task_time);
+}
+_TreecursionPlayer::_TreecursionPlayer() {
+	_singleton = this;	
+}
+_TreecursionPlayer::~_TreecursionPlayer() {
+	_singleton = nullptr;
+}

--- a/modules/talkingtree_storage/treecursion_player.h
+++ b/modules/talkingtree_storage/treecursion_player.h
@@ -1,0 +1,73 @@
+#ifndef TREECURSION_PLAYER_H
+#define TREECURSION_PLAYER_H
+
+#include "object.h"
+#include "variant.h"
+#include "core/os/thread.h"
+#include "core/os/mutex.h"
+#include "treecursion_reader.h"
+
+class TreecursionPlayer : public Object {
+	GDCLASS(TreecursionPlayer, Object);
+
+	static TreecursionPlayer *_singleton;
+	static void thread_func(void *p_udata);
+public:
+	static TreecursionPlayer *get_singleton();
+	void lock();
+	void unlock();
+	void finish();
+	Error init();
+
+private:
+	bool _thread_exited;
+	mutable bool _exit_thread;
+	Thread *_thread;
+	Mutex *_mutex;
+
+protected:
+	static void _bind_methods();
+
+private:
+	enum PLAYING_STATE {
+		ERROR,
+		PAUSED,
+		RUNNING,
+	};
+	PLAYING_STATE state;
+	Ref<TreecursionReader> reader;
+	void push_task(const Ref<TreecursionWriteTask> &task);
+	void flush();
+
+public:
+	void close_file();
+	bool is_paused() const;
+	void set_pause(bool paused);
+	Variant get_init_vars() const;
+	void set_treecursion_reader(Ref<Treecursion> &file);
+	void print_all_task_time();
+	TreecursionPlayer();
+	~TreecursionPlayer();
+	
+};
+
+class _TreecursionPlayer : public Object {
+	GDCLASS(_TreecursionPlayer, Object);
+
+	friend class TreecursionPlayer;
+	static _TreecursionPlayer *_singleton;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static _TreecursionPlayer *get_singleton() { return _singleton; }
+	Variant get_init_values() const;
+	void print_all_task_time();
+	void set_pause(bool paused);
+	void set_treecursion_reader(Ref<Treecursion> in_reader);
+	_TreecursionPlayer();
+	~_TreecursionPlayer();
+};
+
+#endif

--- a/modules/talkingtree_storage/treecursion_reader.cpp
+++ b/modules/talkingtree_storage/treecursion_reader.cpp
@@ -1,58 +1,207 @@
 #include "treecursion_reader.h"
 #include "print_string.h"
+#include "variant.h"
+#include "variant_parser.h"
 #include "ogg_routines.h"
 #include <skeleton/skeleton.h>
 //https://bluishcoder.co.nz/2009/06/24/reading-ogg-files-using-libogg.html
 
 void TreecursionReader::_bind_methods(){
-	ClassDB::bind_method(D_METHOD("print_fishhead"), &TreecursionReader::print_fishhead);
 }
 Error TreecursionReader::set_file(const String &p_file) {
-    file = p_file;
 	Error err;
-	_file = FileAccess::open(file, FileAccess::READ, &err);
+	_file = FileAccess::open(p_file, FileAccess::READ, &err);
 	if (err) {
 		ERR_FAIL_COND_V(err, err);
+		return err;
 	}
+	//buffer the first kilobytes
 	int ret = ogg_sync_init(&state);
-	
+	if(ogg_buffer(_file, &state) <= 0)
+		return ERR_FILE_CANT_READ;
+
+	//load header pages
+	int page_type = next_page();
+	while(page_type == 1) {
+		page_type = next_page();
+	}
+	if( page_type < 0 )
+		return FAILED;
 	return OK;
 }
-void TreecursionReader::print_fishhead(){
-	ogg_page og;
-	ogg_packet op;
-	ogg_stream_state os;
-	OggSkeleton *skeleton = oggskel_new();
-	int sk_headers = -1;
 
-	int ret = ogg_buffer(_file, &state);
-	if (ret == 0) {
-		print_line("error cannot buffer ogg file");
-		return;
-	}
-	int got_packet;
-	if(ogg_sync_pageout (&state, &og) > 0){
-		ogg_stream_init (&os, ogg_page_serialno (&og));
-		ogg_stream_pagein (&os, &og);
-		got_packet = ogg_stream_packetpeek (&os, &op);
-		if((sk_headers = oggskel_decode_header (skeleton, &op)) > 0){
-			char **msg_header;
-			oggskel_get_msg_header(skeleton, 0, msg_header);
-			int64_t ptime;
-			oggskel_get_ptime_num(skeleton, &ptime);
-			String message(*msg_header);
-			print_line("ptime: " + itos(ptime));
-			print_line("attempting to print message");
-			print_line(message);
-		}else{
-			print_line("not skeleton header");
+TreecursionWriteTask* TreecursionReader::variant2write_task(int64_t time, const Variant & cmd){
+	Dictionary dict  = Dictionary(cmd).duplicate();
+	switch( int64_t(dict["type"])){
+		case TreecursionWriteTask::SET_TASK:{
+			//dict["time"] = time;
+			return memnew(TreecursionSetTask(dict));
+			break;
 		}
-	}else{
-		print_line("error reading page");
+		case TreecursionWriteTask::CALL_TASK:{
+			//dict["time"] = time;
+			return memnew(TreecursionCallTask(dict));
+			break;
+		}
+		case TreecursionWriteTask::ENGINE_HEADER_TASK: {
+			return memnew(TreecursionEngineHeaderTask(time, dict));
+			break;
+		}
+		case TreecursionWriteTask::VOICE_TASK:{
+			//return Ref<TreecursionVoiceTask>(memnew(TreecursionVoiceTask(dict)));
+			//return Ref<TreecursionWriteTask>(nullptr);
+			break;
+		}
+		default : {
+			break;
+		}
+	}
+	return nullptr;
+}
+uint64_t TreecursionReader::peek_time() {
+	List<TreecursionWriteTask*>::Element *e = treecursion_buffer.front();
+	return e->get()->get_time();
+}
+
+int TreecursionReader::next_page() {
+	ogg_page og;
+	ogg_page_init(&og);
+	//loop until a page pops out
+	while(ogg_sync_pageout(&state, &og) < 1){
+		if(_file->eof_reached())
+			return -1;
+		
+		if ( ogg_buffer(_file, &state) <= 0 ){
+			return -1;
+		}
+	}
+	return parse_page(&og);
+}
+// check libogg for memory leaks
+int TreecursionReader::parse_page(ogg_page *og) {
+	int serialno = ogg_page_serialno(og);
+	//print_line( "page graulepos : " + itos(ogg_page_granulepos(og)));
+	if(ogg_page_bos(og) > 0){
+		HtoggStream *htogg_stream = memnew(HtoggStream(serialno));
+		open_streams.set(serialno, htogg_stream);
+		ogg_stream_pagein( &(htogg_stream->os), og);
+		
+		ogg_packet op;
+		ogg_packet_init(&op);
+		while(ogg_stream_packetout(&(htogg_stream->os), &op) > 0 ){
+			parse_headers(serialno, &op);
+			ogg_packet_clear(&op);
+		}
+		return 1;
+	} else {
+		HtoggStream *stream = open_streams.get(serialno);
+		ogg_stream_pagein( &(stream->os), og);
+
+		ogg_packet op;
+		ogg_packet_init(&op);
+		while(ogg_stream_packetout(&(stream->os), &op) > 0 ){
+			parse_packet(serialno, &op);
+			//stupid line just crashes even when the packet is valid
+			//ogg_packet_clear(&op);
+			ogg_packet_init(&op);
+		}
+		if( ogg_page_eos(og) > 0)
+			return 2;
+		else
+			return 0;
+	}
+	return -1;
+}
+void TreecursionReader::parse_headers(int type, ogg_packet *op) {
+	VariantParser::StreamString ss;
+	VariantParser parser;
+	String err_string;
+	Variant ret;
+	int err_line;
+	switch(type){
+		case HTOGG_ENGINE: {
+			ss.s.parse_utf8((char *) op->packet, op->bytes);
+			Error err_ret = parser.parse(&ss, ret, err_string, err_line);
+			// nullptr would crash if nullptr are are pushed
+			TreecursionWriteTask *cmd = memnew(TreecursionEngineHeaderTask(op->granulepos, ret));
+			headers.push_back(cmd);
+			break;
+		}
+		default:
+			break;
 	}
 
 }
+void TreecursionReader::parse_packet(int type, ogg_packet *op) {
+	if(op->bytes == 0)
+		return;
+	TreecursionWriteTask * task = NULL;
+	VariantParser::StreamString ss;
+	VariantParser parser;
+	String err_string;
+	Variant ret;
+	int err_line;
+	switch(type){
+		case HTOGG_ENGINE: {
+			ss.s.parse_utf8((char *) op->packet, op->bytes);
+			Error err_ret = parser.parse(&ss, ret, err_string, err_line);
+			// nullptr would crash if nullptr are are pushed
+			TreecursionWriteTask *cmd = variant2write_task(op->granulepos, ret);
+			treecursion_buffer.push_back(cmd);
+			current_granulepos = op->granulepos;
+			break;
+		}
+		case HTOGG_VOIP: {
+			
+		}
+		default:
+			break;
+	}
+}
 
-TreecursionReader::TreecursionReader() {
-    
+Ref<TreecursionWriteTask> TreecursionReader::pop() {
+	Ref<TreecursionWriteTask> ret(treecursion_buffer.front()->get());
+	treecursion_buffer.pop_front();
+	if(treecursion_buffer.empty()) {
+		int err = next_page();
+		if(err > 0) {
+			WARN_PRINTS("Error parsing page");
+		}
+	}
+	return ret;
+}
+Ref<TreecursionWriteTask> TreecursionReader::next() {
+	return Ref<TreecursionWriteTask>(nullptr);
+}
+bool TreecursionReader::has_next() {
+	return !treecursion_buffer.empty();
+}
+Variant TreecursionReader::get_init_values() const {
+	if(headers.empty())
+		return Variant();
+	TreecursionWriteTask *engineHeader = headers[0];
+	TreecursionEngineHeaderTask *e = (TreecursionEngineHeaderTask * ) engineHeader;
+	return e->get_vars();
+}
+void TreecursionReader::close() {
+	ogg_sync_clear(&state);
+	if(_file){
+		if(_file->is_open()){
+			//for some reason it closes on eof.
+			//i have to research this behavior
+			memdelete(_file);
+		}
+		_file = nullptr;
+	}
+	headers.clear();
+	treecursion_buffer.clear();
+	open_streams.clear();
+}
+
+TreecursionReader::TreecursionReader() : _file(nullptr) {
+    headers.clear();
+	treecursion_buffer.clear();
+}
+TreecursionReader::~TreecursionReader() {
+	close();
 }

--- a/modules/talkingtree_storage/treecursion_reader.h
+++ b/modules/talkingtree_storage/treecursion_reader.h
@@ -1,29 +1,77 @@
+#ifndef TREECURSION_H
+#define TREECURSION_H
 #include "resource.h"
 #include "reference.h"
 
-#ifndef TREECURSION_H
-#define TREECURSION_H
-
+#include "io/treecursion_types.h"
 #include "os/file_access.h"
+#include "list.h"
+#include "hash_map.h"
+#include "variant.h"
 #include <ogg/ogg.h>
 
-class TreecursionReader : public Resource{
+class HtoggStream : public Resource {
+    GDCLASS(HtoggStream, Resource);
+public:
+    ogg_stream_state os;
+    ogg_int64_t serial_no;
+    HtoggStream( int num ) : serial_no(num) {
+        ogg_stream_init(&os, num);
+    }
+    ~HtoggStream() {
+        ogg_stream_clear(&os);
+    }
+};
+
+class TreecursionReader : public Resource {
     GDCLASS(TreecursionReader, Resource);
     
-public:   
+public:
     Error set_file(const String &p_file);
-    void print_fishhead();
-
+    Ref<TreecursionWriteTask> next();
+    Ref<TreecursionWriteTask> pop();
+    bool has_next();
+    uint64_t peek_time();
+    Variant get_init_values() const;
     TreecursionReader();
-
+    ~TreecursionReader();
+    
 protected:
     static void _bind_methods();
 
 private:
-    String file;
+    List<TreecursionWriteTask *> headers;
+    List<TreecursionWriteTask *> treecursion_buffer;
+    HashMap<int, HtoggStream *> open_streams;
     FileAccess *_file;
-
     ogg_sync_state state;
-    
+
+
+    ogg_int64_t current_unit;
+    ogg_int64_t current_granulepos;
+    /* Read positioning */
+    long current_page_bytes;
+    /* Calculation of position */
+    //oggz_off_t current_packet_begin_page_offset;
+    int current_packet_pages;
+    int current_packet_begin_segment_index;
+    TreecursionWriteTask* variant2write_task(int64_t time, const Variant & cmd);
+    void parse_packet(int type, ogg_packet *);
+    void parse_headers(int type, ogg_packet *op);
+    int parse_page(ogg_page *);
+    int next_page();
+    void close();
 };
+
+class Treecursion : public Resource {
+	GDCLASS(Treecursion, Resource)
+	String file;
+public:
+	Ref<TreecursionReader> instance_playback() const {
+		Ref<TreecursionReader> pb(memnew(TreecursionReader));
+		pb->set_file(file);
+		return pb;
+	}
+	void set_file(const String &p_file) { file = p_file; }
+}; 
 #endif

--- a/modules/talkingtree_storage/treecursion_writer.cpp
+++ b/modules/talkingtree_storage/treecursion_writer.cpp
@@ -2,71 +2,19 @@
 #include "os/os.h"
 #include "ogg_routines.h"
 #include "os/copymem.h"
-#include <skeleton/skeleton.h>
-#include <skeleton/skeleton_query.h>
 
 void TreecursionWriter::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("close"), &TreecursionWriter::close);
 }
 
+//TODO: Check if its little endian
 //TODO: mime type should be in the msg header field
 // https://xiph.org/ogg/doc/rfc3533.txt
-/*
-void TreecursionWriter::write_header(){
-	OggSkeleton *header = oggskel_new();
-	ogg_packet fishbone_op;
-	ogg_packet fishhead_op;
-	//the only way to add an bone
-	
-	
-	
-	int64_t pna = OS::get_singleton()->get_unix_time();
-	oggskel_set_ptime_num(header, pna);
-	oggskel_set_btime_num(header, 0);
-	
-
-	oggskel_encode_add_stream(header,1);
-	oggskel_set_start_granule(header, 1, 0);
-	oggskel_set_preroll(header, 1, 0);
-	oggskel_set_num_headers(header, 1, 1);
-	oggskel_set_msg_header(header, 1, "i hope that i can read this");
-
-	//encode to write
-	//I need to call it twice because encode header have three states
-	oggskel_encode_header(header, &fishhead_op);
-	oggskel_encode_header(header, &fishbone_op);
-	ogg_stream_packetin(&engine_os, &fishhead_op);
-	ogg_stream_packetin(&engine_os, &fishbone_op);
-
-	ogg_stream_flush(&engine_os, &og);
-
-	char **msg;
-	int64_t ptime;
-	OggSkeletonError err =  oggskel_get_ptime_num(header, &ptime);
-	print_line("get error oggskelton: "+ itos((int)err));
-	oggskel_get_msg_header(header, 0, msg);
-	print_line("msg" + String(*msg));
-
-	print_line("current2 time " + itos(pna));
-	print_line("current time " + itos(ptime));
-
-	print_line("header size" + itos(og.header_len));
-	print_line("body size" + itos(og.body_len));
-
-	htogg_write_page(&og, _fout);
-	
-	//cleanup
-	ogg_packet_clear(&fishhead_op);
-	ogg_packet_clear(&fishbone_op);
-	oggskel_destroy(header);
-}*/
-//TODO: Check if its little endian
 void TreecursionWriter::write_task( const TreecursionWriteTask & task ){
 	ogg_packet op;
 	PoolByteArray packet_data;
 
-	op.b_o_s = 0;
-
+	ogg_packet_init(&op);
 	//create packet data
 	switch(task.get_type()){
 		case TreecursionWriteTask::ENGINE_HEADER_TASK: {
@@ -95,7 +43,7 @@ void TreecursionWriter::write_task( const TreecursionWriteTask & task ){
 					return; 
 				}
 			}
-			last_value[st->get_node_path()] = st -> get_value();
+			last_value.set(st->get_node_path(), st -> get_value());
 			CharString s = task.toString().utf8();
 			op.bytes = s.size();
 			packet_data.resize(s.size());
@@ -109,16 +57,22 @@ void TreecursionWriter::write_task( const TreecursionWriteTask & task ){
 	}
 	unsigned char *rptr = (unsigned char *) packet_data.read().ptr();
 	op.packet = rptr;
-	op.granulepos = task.get_time();
+	op.granulepos = (ogg_int64_t) task.get_time();
 	op.packetno = _sequence_number;
 	op.bytes = packet_data.size();
 	_sequence_number += 100;
 
 	ogg_stream_packetin(&ogg_os[HTOGG_ENGINE], &op);
+	//ogg_packet_clear(&op);
 
 	ogg_page og;
+	ogg_page_init(&og);
+	//print_line(" state granuelopos: " + itos(op.granulepos) + " : " + itos(ogg_os[HTOGG_ENGINE].granulepos));
+	//state and current page granuelopos is the same
 	if(ogg_stream_pageout(&ogg_os[HTOGG_ENGINE], &og) > 0){
 		htogg_write_page(&og, _fout);
+		//seems to crash
+		//ogg_page_clear(&og);
 	}
 }
 
@@ -137,10 +91,9 @@ void TreecursionWriter::close(){
 		}*/
 		//only handle engine for now
 		ogg_packet op;
-		op.granulepos = OS::get_singleton()->get_ticks_usec();
+		ogg_packet_init(&op);
+		op.granulepos = (ogg_int64_t) OS::get_singleton()->get_ticks_usec();
 		op.e_o_s = 1;
-		op.bytes = 0;
-		op.b_o_s = 0;
 		ogg_stream_packetin(&ogg_os[HTOGG_ENGINE], &op);
 		ogg_page og;
 		ogg_stream_flush( &ogg_os[HTOGG_ENGINE], &og);

--- a/modules/talkingtree_storage/treecursion_writer.h
+++ b/modules/talkingtree_storage/treecursion_writer.h
@@ -20,7 +20,7 @@ private:
     int64_t _sequence_number;
     int serialno;
     HashMap<String, Variant> last_value;
-    ogg_stream_state ogg_os[HTOGG_END]; 
+    ogg_stream_state ogg_os[HTOGG_END];
 
 protected:
     static void _bind_methods();

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -206,11 +206,6 @@ private:
 
 	int rpc_sender_id;
 
-	// added replay data
-	Ref<TreecursionTestData> treecursion_replay_data;
-	void _treecursion_poll();
-	void _execute_treecursion(TreecursionWriteTask *cmd);
-
 	//path sent caches
 	struct PathSentCache {
 		Map<int, bool> confirmed_peers;
@@ -459,8 +454,7 @@ public:
 
 	void set_network_peer(const Ref<NetworkedMultiplayerPeer> &p_network_peer);
 	Ref<NetworkedMultiplayerPeer> get_network_peer() const;
-	//added
-	void set_treecursion_data(const Ref<TreecursionTestData> &treecursion_data);
+	
 	bool is_network_server() const;
 	bool has_network_peer() const;
 	int get_network_unique_id() const;


### PR DESCRIPTION
Clean up Scenetree

TreecursionPlayer uses MessageQueue to submit commands into Scenetree.

Htogg reader is seperated into two classes Treecursion and TreecursionReader.
Treecursion is just a file path container and creates TreecursionReader with
instance_playback.

Treecursion manages file state and reads htogg format

currently, the bos page is just a holder for Godot Dictionary of init variables
Each packet has a utf8 time as access with the "time" key.

Each packet keys varies depending on whether or not they are call or set
commands

Pause and voip are not supported at the momemnt.

Only engine commands